### PR TITLE
Pull from base

### DIFF
--- a/listree.h
+++ b/listree.h
@@ -60,10 +60,10 @@ typedef enum {
     LT_CIF  =0x00000100, // CVAR of type ffi_cif (for reflection)
     LT_NULL =0x00000200, // empty
     LT_IMM  =0x00000400, // immediate value, not a pointer
-    LT_NOWC =0x00000800, // do not do wildcard matching
-    LT_BC   =0x00001000, // VM bytecode
-    LT_DERV =0x00002000, // Derived from another LTV (cannot be an LT_LIST)
-
+    LT_ARR  =0x00000800, // data is a pointer to 1st element of an array
+    LT_NOWC =0x00001000, // do not do wildcard matching
+    LT_BC   =0x00002000, // VM bytecode
+    LT_DERV =0x00004000, // Derived from another LTV (cannot be an LT_LIST)
 
     LT_RO   =0x00010000, // META: disallow release
     LT_AVIS =0x00020000, // META: absolute traversal visitation flag

--- a/reflect.c
+++ b/reflect.c
@@ -497,6 +497,18 @@ int cif_dump_cvar(FILE *ofile,LTV *cvar,int depth)
     CLL_init(&queue);
     LTV_enq(&queue,cif_create_cvar(type,cvar->data,NULL),TAIL); // copy cvar so we don't mess with it
 
+    int traverse_array(LTV *cvar,int count)
+    {
+        int status=0;
+        STRY(!(type=LT_get(cvar,TYPE_BASE,HEAD,KEEP)),"looking up cvar type");
+        TYPE_INFO_LTV *type_info=(TYPE_INFO_LTV *) type->data;
+        for (int i=0;i<count;i++) {
+            cif_dump_cvar(ofile,cvar,depth+4);
+            cvar->data+=type_info->bytesize;
+        }
+    done:
+        return status;
+    }
     int process_type_info(LTV *cvar) {
         int status=0;
         LTV *type=NULL;
@@ -540,9 +552,24 @@ int cif_dump_cvar(FILE *ofile,LTV *cvar,int depth)
                 case DW_TAG_pointer_type:
                     fprintf(ofile,"0x%x",*(void **) type->data);
                     break;
-                case DW_TAG_array_type:
-                    fprintf(ofile,"(array display unimplemented)");
+                case DW_TAG_array_type: {
+                    TYPE_INFO_LTV *base_info=NULL;
+                    if (type_info->flags&TYPEF_BASE) // link to base type
+                        STRY(!(base_info=(TYPE_INFO_LTV *) LT_get(&type_info->ltv,TYPE_BASE,HEAD,KEEP)),"looking up base die for %s",type_info->id_str);
+                    char *base_symb=base_info && (base_info->flags&TYPEF_SYMBOLIC)? attr_get(&base_info->ltv,TYPE_SYMB):NULL;
+                    if (base_symb) {
+                        LTV *subrange_ltv=LT_get(&type_info->ltv,"subrange type",HEAD,KEEP);
+                        TYPE_INFO_LTV *subrange=subrange_ltv?(TYPE_INFO_LTV *) subrange_ltv->data:NULL;
+                        if (subrange && subrange->flags&TYPEF_UPPERBOUND) {
+                            LTV *tcvar=cif_create_cvar(&base_info->ltv,cvar->data,NULL);
+                            traverse_array(tcvar,subrange->upper_bound+1);
+                            LTV_release(tcvar);
+                        }
+                        else
+                            fprintf(ofile,"(unbounded array of %s)",base_symb);
+                    }
                     break;
+                }
                 case DW_TAG_enumeration_type:
                     fprintf(ofile,"(enum display unimplemented)");
                     break;
@@ -2063,12 +2090,32 @@ int is_readable(LTV *type)
 }
 
 // convert interpreter params into something FFI can use
+extern void print_type(LTV *ltv,char *prefix)
+{
+    int old_show_ref=show_ref;
+    show_ref=1;
+    if (prefix)
+        printf("%s",prefix);
+    print_ltv(stdout,NULL,ltv,NULL,2);
+    show_ref=old_show_ref;
+}
+
+// look for explicit indication of type compatibility
+int cif_is_compatible(LTV *a,LTV *b)
+{
+    if (!a || !b)
+        return false;
+    if (a==b)
+        return true;
+    if (basic_ffi_ltv(a)==basic_ffi_ltv(b))
+        return true;
+    return false;
+}
 // (encaps LTVs into LTV cvars, cast basic types, ref/deref pointers, ...)
 LTV *cif_coerce_i2c(LTV *ltv,LTV *type)
 {
     int status=0;
     LTV *result=ltv;
-    TYPE_UVALUE dst_uval={},src_uval={};
 
     /*
     int old_show_ref=show_ref;
@@ -2090,6 +2137,7 @@ LTV *cif_coerce_i2c(LTV *ltv,LTV *type)
         else if (match("(char)*") || match("(unsigned char)*")) // ltv data -> char array
             STRY(!(result=cif_create_cvar(type_base,&ltv->data,NULL)),"creating string coersion"); // cvar->data=&ltv->data, i.e. cvar will point to a void*
         else if (is_readable(type_base)) {
+            TYPE_UVALUE dst_uval={},src_uval={};
             result=cif_create_cvar(type,NULL,NULL);
             Type_getUVAL(result,&dst_uval); // try to read plaintext into a base type
             Type_putUVAL(result,Type_pullUVAL(&dst_uval,ltv->data));
@@ -2102,7 +2150,7 @@ LTV *cif_coerce_i2c(LTV *ltv,LTV *type)
 
     LTV *cvar_base=LT_get(ltv,TYPE_BASE,HEAD,KEEP);
     if (type_base && cvar_base) {
-        if (type_base==cvar_base)
+        if (cif_is_compatible(type_base,cvar_base))
             result=ltv;
         else {
             LTV *meta=cif_get_meta(cvar_base);
@@ -2110,6 +2158,8 @@ LTV *cif_coerce_i2c(LTV *ltv,LTV *type)
                 result=cif_put_meta(ltv,meta);
             else if (match("(LTV)*"))
                 result=encaps_ltv(ltv);
+            else
+                STRY((vm_throw(LTV_NULL),1),"no i2c coersion");
         }
     }
  done:

--- a/test/makefile
+++ b/test/makefile
@@ -5,9 +5,9 @@ cmake: build; cd build && cmake ..
 compile: cmake; make -C build
 clean: cmake; make -C build clean
 
-testh.so: ; gcc -g3 --shared -std=gnu99 -ggdb3 -gdwarf-4 -fno-eliminate-unused-debug-types -o $@ testh.c
-test.so: ; gcc -g3 --shared -std=gnu99 -ggdb3 -gdwarf-4 -fno-eliminate-unused-debug-types -o $@ test.c
-math.so: ; gcc -g3 --shared -std=gnu99 -ggdb3 -gdwarf-4 -fno-eliminate-unused-debug-types -o $@ math.c
+testh.so: testh.c; gcc -g3 --shared -std=gnu99 -ggdb3 -gdwarf-4 -fno-eliminate-unused-debug-types -o $@ $<
+test.so: test.c; gcc -g3 --shared -std=gnu99 -ggdb3 -gdwarf-4 -fno-eliminate-unused-debug-types -o $@ $<
+math.so: math.c; gcc -g3 --shared -std=gnu99 -ggdb3 -gdwarf-4 -fno-eliminate-unused-debug-types -o $@ $<
 
 libify:
 	gcc -c -g -fPIC math.c -o math.o


### PR DESCRIPTION
A) Add automatic base-type coersions, and B) differentiate between pointers and arrays when marshalling ffi arguments
After this pull, pxpf master will point to plexx/j2 rather than jasonnyberg/j2 so these pulls won't happen nearly as often.